### PR TITLE
Add multi-archive architecture, security hardening, and fuzzing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2025-12-31
+
+### Added
+
+- **TAR Support**: Extract `.tar` and `.tar.gz` archives with the same security guarantees
+  - `Driver::extract_tar()`, `extract_tar_file()`, `extract_tar_gz_file()`
+  - `TarAdapter` for the new architecture
+- **New Architecture**: Modular design with Adapters, Policies, and Driver
+  - `Driver` - generic extraction engine
+  - `ZipAdapter`, `TarAdapter` - format-specific handlers
+  - `Policy` trait with `PathPolicy`, `SizePolicy`, `CountPolicy`, `DepthPolicy`, `SymlinkPolicy`
+  - `PolicyChain` for composing multiple policies
+- **Encryption Detection**: Error on encrypted ZIP entries with clear message
+- **Atomic File Creation**: Uses `create_new(true)` for `OverwriteMode::Error/Skip` to prevent TOCTOU races
+- **Device File Rejection**: TAR entries with block devices, char devices, or FIFOs now error with `UnsupportedEntryType`
+- **Fuzzing Setup**: `cargo-fuzz` with `fuzz_extract` and `fuzz_zip_adapter` targets
+- **12 New TAR Security Tests**: Block/char devices, FIFOs, absolute paths, symlinks, setuid stripping, limits
+
+### Changed
+
+- **Improved Error Messages**:
+  - `SymlinkNotAllowed` now shows target path (e.g., `'link' -> '/etc/passwd'`)
+  - `FileCountExceeded` clarifies stopping point
+  - `AlreadyExists` uses `entry` field for consistency
+- **`#[non_exhaustive]` on `Error` enum**: Future error variants won't break exhaustive matches
+
+### Python Bindings
+
+- Added `UnsupportedEntryTypeError` exception
+- Updated error messages to match Rust improvements
+
 ## [0.1.1] - 2025-12-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -232,6 +232,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -347,6 +359,17 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -540,6 +563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,7 +581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -560,16 +592,18 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "safe_unzip"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
+ "flate2",
  "path_jail",
+ "tar",
  "tempfile",
  "zip",
 ]
 
 [[package]]
 name = "safe_unzip_python"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "pyo3",
  "safe_unzip",
@@ -645,6 +679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +705,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -788,6 +833,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -796,10 +850,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_unzip"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tenuo-ai/safe_unzip"
@@ -16,6 +16,8 @@ members = [".", "python"]
 [dependencies]
 path_jail = "0.2"
 zip = "2.1"
+tar = "0.4"
+flate2 = "1"  # For .tar.gz support
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ let report = Extractor::new("/var/uploads")?
 | **Invalid Filename** | Control chars, `CON`, `NUL` | Filename sanitization |
 | **Overwrite** | Replace sensitive files | `OverwritePolicy::Error` default |
 | **Setuid** | Create setuid executables | Permission bits stripped |
+| **Encrypted Archives** | Password handling complexity | Rejected (see [Encrypted Archives](#encrypted-archives)) |
 
 ## Default Limits
 
@@ -300,8 +301,11 @@ match extract_file("/var/uploads", "archive.zip") {
     Err(Error::AlreadyExists { path }) => {
         eprintln!("File already exists: {}", path);
     }
-    Err(Error::InvalidFilename { entry }) => {
+    Err(Error::InvalidFilename { entry, .. }) => {
         eprintln!("Invalid filename: {}", entry);
+    }
+    Err(Error::EncryptedEntry { entry }) => {
+        eprintln!("Encrypted entry not supported: {}", entry);
     }
     Err(e) => {
         eprintln!("Extraction failed: {}", e);
@@ -315,7 +319,17 @@ match extract_file("/var/uploads", "archive.zip") {
 
 - **Zip format only** — Tar/gzip support planned for v0.2
 - **Requires seekable input** — No stdin streaming (zip format requires reading the central directory at the end of the file)
-- **No password-protected zips** — Use the `zip` crate directly for encrypted archives
+- **No encrypted archives** — See below
+
+### Encrypted Archives
+
+`safe_unzip` does not support password-protected zip files. Encrypted entries are rejected with `Error::EncryptedEntry`.
+
+If you need to extract encrypted archives:
+1. Decrypt first using the `zip` crate directly
+2. Then extract with `safe_unzip`
+
+This is intentional—encryption handling is outside our security scope. Password management, key derivation, and cryptographic validation are complex domains that deserve dedicated tooling.
 
 ### Extraction Behavior
 
@@ -330,10 +344,16 @@ These threats are **not fully addressed** (by design or complexity):
 |------------|--------|
 | **Case-insensitive collisions** | On Windows/macOS, `File.txt` and `file.txt` map to the same file. We don't track extracted names to detect this. |
 | **Unicode normalization** | `café` (NFC) vs `café` (NFD) appear identical but are different bytes. Full normalization requires ICU. |
-| **TOCTOU race conditions** | Between path validation and file creation, a symlink could theoretically be created. Mitigated by secure overwrite, but not fully atomic. |
+| **Concurrent extraction** | If multiple threads/processes extract to the same destination, race conditions can occur. Use file locking or separate destinations. |
 | **Sparse file attacks** | Not applicable to zip format. |
 | **Hard links** | Zip format doesn't support hard links. |
 | **Device files** | Zip format doesn't support special device files. |
+
+### TOCTOU Mitigations
+
+For `OverwriteMode::Error` and `OverwriteMode::Skip`, we use **atomic file creation** (`O_CREAT | O_EXCL`) instead of check-then-create. This eliminates race conditions between checking if a file exists and creating it.
+
+For `OverwriteMode::Overwrite`, symlinks are removed before writing to prevent symlink-following attacks, but there's a brief window between removal and creation.
 
 ### Filename Restrictions
 
@@ -344,6 +364,25 @@ These filenames are **rejected** for security:
 - Paths longer than 1024 bytes
 - Path components longer than 255 bytes
 - Windows reserved names: `CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9`
+
+## Development
+
+### Fuzzing
+
+We use [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) with two targets:
+
+```bash
+# Install cargo-fuzz (requires nightly)
+cargo install cargo-fuzz
+
+# Run the main extraction fuzzer
+cargo +nightly fuzz run fuzz_extract
+
+# Run the adapter fuzzer (tests parsing layer)
+cargo +nightly fuzz run fuzz_zip_adapter
+```
+
+Fuzzing targets are in `fuzz/fuzz_targets/`. Run fuzzing before releases to catch parsing edge cases.
 
 ## License
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "safe_unzip-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+tempfile = "3"
+
+[dependencies.safe_unzip]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_extract"
+path = "fuzz_targets/fuzz_extract.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_zip_adapter"
+path = "fuzz_targets/fuzz_zip_adapter.rs"
+test = false
+doc = false
+bench = false
+

--- a/fuzz/fuzz_targets/fuzz_extract.rs
+++ b/fuzz/fuzz_targets/fuzz_extract.rs
@@ -1,0 +1,24 @@
+//! Fuzz test for the main extraction API.
+//!
+//! This target tests the complete extraction pipeline with arbitrary byte input,
+//! catching panics in zip parsing, path handling, and file writing.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+use tempfile::tempdir;
+
+fuzz_target!(|data: &[u8]| {
+    // Create a temporary directory for extraction
+    let Ok(dest) = tempdir() else { return };
+    
+    // Wrap the fuzz input as a seekable reader
+    let reader = Cursor::new(data);
+    
+    // Try to extract using the main API
+    // We don't care about the result - we're looking for panics
+    let _ = safe_unzip::Extractor::new(dest.path())
+        .map(|e| e.extract(reader));
+});
+

--- a/fuzz/fuzz_targets/fuzz_zip_adapter.rs
+++ b/fuzz/fuzz_targets/fuzz_zip_adapter.rs
@@ -1,0 +1,31 @@
+//! Fuzz test for the ZipAdapter (new architecture).
+//!
+//! This target tests the adapter layer which parses ZIP headers and metadata,
+//! catching panics in the parsing logic before extraction occurs.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+use tempfile::tempdir;
+
+fuzz_target!(|data: &[u8]| {
+    // Wrap the fuzz input as a seekable reader
+    let reader = Cursor::new(data);
+    
+    // Try to create a ZipAdapter and read metadata
+    if let Ok(mut adapter) = safe_unzip::ZipAdapter::new(reader) {
+        // Try to read all entry metadata (no decompression)
+        let _ = adapter.entries_metadata();
+        
+        // If that worked, try extraction with the Driver
+        let reader2 = Cursor::new(data);
+        if let Ok(adapter2) = safe_unzip::ZipAdapter::new(reader2) {
+            if let Ok(dest) = tempdir() {
+                let _ = safe_unzip::Driver::new(dest.path())
+                    .map(|d| d.extract_zip(adapter2));
+            }
+        }
+    }
+});
+

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_unzip_python"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tenuo-ai/safe_unzip"

--- a/python/python/safe_unzip/__init__.py
+++ b/python/python/safe_unzip/__init__.py
@@ -32,6 +32,7 @@ from safe_unzip._safe_unzip import (
     SymlinkNotAllowedError,
     QuotaError,
     AlreadyExistsError,
+    EncryptedArchiveError,
 )
 
 __all__ = [
@@ -47,6 +48,7 @@ __all__ = [
     "SymlinkNotAllowedError",
     "QuotaError",
     "AlreadyExistsError",
+    "EncryptedArchiveError",
 ]
 
 __version__ = "0.1.0"

--- a/python/python/safe_unzip/__init__.py
+++ b/python/python/safe_unzip/__init__.py
@@ -33,6 +33,7 @@ from safe_unzip._safe_unzip import (
     QuotaError,
     AlreadyExistsError,
     EncryptedArchiveError,
+    UnsupportedEntryTypeError,
 )
 
 __all__ = [
@@ -49,6 +50,7 @@ __all__ = [
     "QuotaError",
     "AlreadyExistsError",
     "EncryptedArchiveError",
+    "UnsupportedEntryTypeError",
 ]
 
 __version__ = "0.1.0"

--- a/python/python/safe_unzip/__init__.pyi
+++ b/python/python/safe_unzip/__init__.pyi
@@ -103,3 +103,7 @@ class EncryptedArchiveError(SafeUnzipError):
     """Archive contains encrypted entries (not supported)."""
     ...
 
+class UnsupportedEntryTypeError(SafeUnzipError):
+    """Archive contains unsupported entry type (device file, fifo, etc.)."""
+    ...
+

--- a/python/python/safe_unzip/__init__.pyi
+++ b/python/python/safe_unzip/__init__.pyi
@@ -99,3 +99,7 @@ class AlreadyExistsError(SafeUnzipError):
     """File already exists and policy is 'error'."""
     ...
 
+class EncryptedArchiveError(SafeUnzipError):
+    """Archive contains encrypted entries (not supported)."""
+    ...
+

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -11,6 +11,7 @@ pyo3::create_exception!(safe_unzip, PathEscapeError, SafeUnzipError);
 pyo3::create_exception!(safe_unzip, SymlinkNotAllowedError, SafeUnzipError);
 pyo3::create_exception!(safe_unzip, QuotaError, SafeUnzipError);
 pyo3::create_exception!(safe_unzip, AlreadyExistsError, SafeUnzipError);
+pyo3::create_exception!(safe_unzip, EncryptedArchiveError, SafeUnzipError);
 
 fn to_py_err(err: safe_unzip::Error) -> PyErr {
     match err {
@@ -55,6 +56,10 @@ fn to_py_err(err: safe_unzip::Error) -> PyErr {
         safe_unzip::Error::InvalidFilename { entry, reason } => {
             PathEscapeError::new_err(format!("invalid filename '{}': {}", entry, reason))
         }
+        safe_unzip::Error::EncryptedEntry { entry } => EncryptedArchiveError::new_err(format!(
+            "entry '{}' is encrypted (encrypted archives not supported)",
+            entry
+        )),
         safe_unzip::Error::DestinationNotFound { path } => {
             PyIOError::new_err(format!("destination directory '{}' does not exist", path))
         }
@@ -288,6 +293,10 @@ fn _safe_unzip(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?;
     m.add("QuotaError", py.get_type::<QuotaError>())?;
     m.add("AlreadyExistsError", py.get_type::<AlreadyExistsError>())?;
+    m.add(
+        "EncryptedArchiveError",
+        py.get_type::<EncryptedArchiveError>(),
+    )?;
 
     Ok(())
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1,0 +1,8 @@
+//! Archive format adapters.
+//!
+//! Adapters normalize different archive formats into a common interface
+//! for the extraction engine.
+
+mod zip_adapter;
+
+pub use zip_adapter::ZipAdapter;

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -3,6 +3,8 @@
 //! Adapters normalize different archive formats into a common interface
 //! for the extraction engine.
 
+mod tar_adapter;
 mod zip_adapter;
 
+pub use tar_adapter::{copy_limited, TarAdapter};
 pub use zip_adapter::ZipAdapter;

--- a/src/adapter/tar_adapter.rs
+++ b/src/adapter/tar_adapter.rs
@@ -1,0 +1,220 @@
+//! TAR archive adapter.
+
+use std::fs::File;
+use std::io::{BufReader, Read, Write};
+use std::path::Path;
+
+use flate2::read::GzDecoder;
+
+use crate::entry::{EntryInfo, EntryKind};
+use crate::error::Error;
+
+/// Adapter for TAR archives.
+///
+/// Supports both plain `.tar` and gzip-compressed `.tar.gz` / `.tgz` files.
+///
+/// Unlike ZIP, TAR is a sequential format without a central directory.
+/// This means:
+/// - Entries must be read in order
+/// - `ValidateFirst` mode requires reading the entire archive twice
+/// - Random access to entries is not supported
+pub struct TarAdapter<R: Read> {
+    archive: tar::Archive<R>,
+    /// Cached entries for validation mode (read once, extract later)
+    cached_entries: Option<Vec<CachedEntry>>,
+}
+
+/// Cached entry data for two-pass extraction.
+struct CachedEntry {
+    info: EntryInfo,
+    data: Vec<u8>,
+}
+
+impl<R: Read> TarAdapter<R> {
+    /// Create a new TarAdapter from a reader.
+    ///
+    /// For `.tar.gz` files, wrap the reader in `GzDecoder` first,
+    /// or use `TarAdapter::open_gz()`.
+    pub fn new(reader: R) -> Self {
+        Self {
+            archive: tar::Archive::new(reader),
+            cached_entries: None,
+        }
+    }
+
+    /// Process each entry with a callback.
+    ///
+    /// TAR is sequential, so entries are processed in order.
+    /// The callback receives entry info and a reader for the content.
+    ///
+    /// Return `Ok(true)` to continue, `Ok(false)` to stop, or `Err` to abort.
+    pub fn for_each<F>(&mut self, mut callback: F) -> Result<(), Error>
+    where
+        F: FnMut(EntryInfo, Option<&mut dyn Read>) -> Result<bool, Error>,
+    {
+        let entries = self.archive.entries()?;
+
+        for entry_result in entries {
+            let mut entry = entry_result?;
+            let header = entry.header();
+
+            let name = entry.path()?.to_string_lossy().into_owned();
+
+            let kind = match header.entry_type() {
+                tar::EntryType::Regular | tar::EntryType::Continuous => EntryKind::File,
+                tar::EntryType::Directory => EntryKind::Directory,
+                tar::EntryType::Symlink | tar::EntryType::Link => {
+                    let target = entry
+                        .link_name()?
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    EntryKind::Symlink { target }
+                }
+                // Skip other types (block devices, char devices, fifos, etc.)
+                _ => continue,
+            };
+
+            let info = EntryInfo {
+                name,
+                size: header.size()?,
+                kind: kind.clone(),
+                mode: header.mode().ok(),
+            };
+
+            let continue_extraction = if matches!(kind, EntryKind::File) {
+                callback(info, Some(&mut entry))?
+            } else {
+                callback(info, None)?
+            };
+
+            if !continue_extraction {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read all entries into memory for validation.
+    ///
+    /// This is used by `ValidateFirst` mode to check all entries
+    /// before extracting any. The data is cached for later extraction.
+    pub fn cache_all(&mut self) -> Result<Vec<EntryInfo>, Error> {
+        let mut entries = Vec::new();
+        let mut cached = Vec::new();
+
+        let tar_entries = self.archive.entries()?;
+
+        for entry_result in tar_entries {
+            let mut entry = entry_result?;
+            let header = entry.header();
+
+            let name = entry.path()?.to_string_lossy().into_owned();
+
+            let kind = match header.entry_type() {
+                tar::EntryType::Regular | tar::EntryType::Continuous => EntryKind::File,
+                tar::EntryType::Directory => EntryKind::Directory,
+                tar::EntryType::Symlink | tar::EntryType::Link => {
+                    let target = entry
+                        .link_name()?
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    EntryKind::Symlink { target }
+                }
+                _ => continue,
+            };
+
+            let info = EntryInfo {
+                name: name.clone(),
+                size: header.size()?,
+                kind: kind.clone(),
+                mode: header.mode().ok(),
+            };
+
+            // Read file content into memory
+            let mut data = Vec::new();
+            if matches!(kind, EntryKind::File) {
+                entry.read_to_end(&mut data)?;
+            }
+
+            entries.push(info.clone());
+            cached.push(CachedEntry { info, data });
+        }
+
+        self.cached_entries = Some(cached);
+        Ok(entries)
+    }
+
+    /// Extract cached entries (after cache_all was called).
+    pub fn extract_cached<F>(&mut self, mut callback: F) -> Result<(), Error>
+    where
+        F: FnMut(EntryInfo, Option<&[u8]>) -> Result<bool, Error>,
+    {
+        let cached = self.cached_entries.take().ok_or_else(|| {
+            Error::Io(std::io::Error::other(
+                "no cached entries (call cache_all first)",
+            ))
+        })?;
+
+        for entry in cached {
+            let data = if matches!(entry.info.kind, EntryKind::File) {
+                Some(entry.data.as_slice())
+            } else {
+                None
+            };
+
+            if !callback(entry.info, data)? {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl TarAdapter<BufReader<File>> {
+    /// Open a plain TAR file from a path.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        Ok(Self::new(reader))
+    }
+}
+
+impl TarAdapter<GzDecoder<BufReader<File>>> {
+    /// Open a gzip-compressed TAR file (.tar.gz, .tgz) from a path.
+    pub fn open_gz<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        let decoder = GzDecoder::new(reader);
+        Ok(Self::new(decoder))
+    }
+}
+
+/// Helper to copy with a byte limit.
+pub fn copy_limited<R: Read + ?Sized, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    limit: u64,
+) -> Result<u64, Error> {
+    let mut total = 0u64;
+    let mut buf = [0u8; 8192];
+
+    loop {
+        let remaining = limit.saturating_sub(total);
+        if remaining == 0 {
+            break;
+        }
+
+        let to_read = buf.len().min(remaining as usize);
+        let n = reader.read(&mut buf[..to_read])?;
+        if n == 0 {
+            break;
+        }
+
+        writer.write_all(&buf[..n])?;
+        total += n as u64;
+    }
+
+    Ok(total)
+}

--- a/src/adapter/zip_adapter.rs
+++ b/src/adapter/zip_adapter.rs
@@ -1,0 +1,249 @@
+//! ZIP archive adapter.
+
+use std::fs::File;
+use std::io::{BufReader, Read, Seek, Write};
+use std::path::Path;
+
+use crate::entry::{EntryInfo, EntryKind};
+use crate::error::Error;
+
+/// Adapter for ZIP archives.
+///
+/// Wraps the `zip` crate and provides a format-agnostic interface for extraction.
+pub struct ZipAdapter<R> {
+    archive: zip::ZipArchive<R>,
+}
+
+impl<R: Read + Seek> ZipAdapter<R> {
+    /// Create a new ZipAdapter from a reader.
+    pub fn new(reader: R) -> Result<Self, Error> {
+        let archive = zip::ZipArchive::new(reader)?;
+        Ok(Self { archive })
+    }
+
+    /// Returns the number of entries in the archive.
+    pub fn len(&self) -> usize {
+        self.archive.len()
+    }
+
+    /// Returns true if the archive is empty.
+    pub fn is_empty(&self) -> bool {
+        self.archive.is_empty()
+    }
+
+    /// Get all entry metadata without decompressing (for validation).
+    ///
+    /// Uses `by_index_raw()` to read only headers, not content.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::EncryptedEntry` if any entry is encrypted.
+    pub fn entries_metadata(&mut self) -> Result<Vec<EntryInfo>, Error> {
+        let mut entries = Vec::with_capacity(self.archive.len());
+
+        for i in 0..self.archive.len() {
+            let entry = self.archive.by_index_raw(i)?;
+            let name = entry.name().to_string();
+
+            // Reject encrypted entries
+            if entry.encrypted() {
+                return Err(Error::EncryptedEntry { entry: name });
+            }
+
+            let kind = if entry.is_dir() {
+                EntryKind::Directory
+            } else if entry.is_symlink() {
+                EntryKind::Symlink {
+                    target: String::new(), // Can't read target without decompressing
+                }
+            } else {
+                EntryKind::File
+            };
+
+            entries.push(EntryInfo {
+                name,
+                size: entry.size(),
+                kind,
+                mode: entry.unix_mode(),
+            });
+        }
+
+        Ok(entries)
+    }
+
+    /// Process each entry with a callback.
+    ///
+    /// This design works around the zip crate's lifetime constraints by
+    /// processing entries one at a time through a callback.
+    ///
+    /// The callback receives:
+    /// - `info`: Entry metadata for policy decisions
+    /// - `reader`: A reader to access the entry's content (only for files)
+    ///
+    /// Return `Ok(true)` to continue, `Ok(false)` to stop, or `Err` to abort.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::EncryptedEntry` if any entry is encrypted.
+    pub fn for_each<F>(&mut self, mut callback: F) -> Result<(), Error>
+    where
+        F: FnMut(EntryInfo, Option<&mut dyn Read>) -> Result<bool, Error>,
+    {
+        for i in 0..self.archive.len() {
+            let mut entry = self.archive.by_index(i)?;
+            let name = entry.name().to_string();
+
+            // Reject encrypted entries
+            if entry.encrypted() {
+                return Err(Error::EncryptedEntry { entry: name });
+            }
+
+            // Determine entry kind and read symlink target if applicable
+            let kind = if entry.is_dir() {
+                EntryKind::Directory
+            } else if entry.is_symlink() {
+                let mut target = String::new();
+                entry.read_to_string(&mut target)?;
+                EntryKind::Symlink { target }
+            } else {
+                EntryKind::File
+            };
+
+            let info = EntryInfo {
+                name,
+                size: entry.size(),
+                kind: kind.clone(),
+                mode: entry.unix_mode(),
+            };
+
+            // For files, provide the reader; for dirs/symlinks, no reader needed
+            let continue_extraction = if matches!(kind, EntryKind::File) {
+                callback(info, Some(&mut entry))?
+            } else {
+                callback(info, None)?
+            };
+
+            if !continue_extraction {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extract a single entry by index, writing to the provided writer.
+    ///
+    /// Returns the entry info and number of bytes written.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::EncryptedEntry` if the entry is encrypted.
+    pub fn extract_to<W: Write>(
+        &mut self,
+        index: usize,
+        writer: &mut W,
+        limit: u64,
+    ) -> Result<(EntryInfo, u64), Error> {
+        let mut entry = self.archive.by_index(index)?;
+        let name = entry.name().to_string();
+
+        // Reject encrypted entries
+        if entry.encrypted() {
+            return Err(Error::EncryptedEntry { entry: name });
+        }
+
+        let kind = if entry.is_dir() {
+            EntryKind::Directory
+        } else if entry.is_symlink() {
+            let mut target = String::new();
+            entry.read_to_string(&mut target)?;
+            EntryKind::Symlink { target }
+        } else {
+            EntryKind::File
+        };
+
+        let info = EntryInfo {
+            name,
+            size: entry.size(),
+            kind: kind.clone(),
+            mode: entry.unix_mode(),
+        };
+
+        let bytes_written = if matches!(kind, EntryKind::File) {
+            copy_limited(&mut entry, writer, limit)?
+        } else {
+            0
+        };
+
+        Ok((info, bytes_written))
+    }
+
+    /// Get entry info by index without reading content.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::EncryptedEntry` if the entry is encrypted.
+    pub fn entry_info(&mut self, index: usize) -> Result<EntryInfo, Error> {
+        let entry = self.archive.by_index_raw(index)?;
+        let name = entry.name().to_string();
+
+        // Reject encrypted entries
+        if entry.encrypted() {
+            return Err(Error::EncryptedEntry { entry: name });
+        }
+
+        let kind = if entry.is_dir() {
+            EntryKind::Directory
+        } else if entry.is_symlink() {
+            EntryKind::Symlink {
+                target: String::new(),
+            }
+        } else {
+            EntryKind::File
+        };
+
+        Ok(EntryInfo {
+            name,
+            size: entry.size(),
+            kind,
+            mode: entry.unix_mode(),
+        })
+    }
+}
+
+impl ZipAdapter<BufReader<File>> {
+    /// Open a ZIP file from a path.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        Self::new(reader)
+    }
+}
+
+/// Copy with a byte limit, returning bytes written.
+fn copy_limited<R: Read, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    limit: u64,
+) -> Result<u64, Error> {
+    let mut total = 0u64;
+    let mut buf = [0u8; 8192];
+
+    loop {
+        let remaining = limit.saturating_sub(total);
+        if remaining == 0 {
+            break;
+        }
+
+        let to_read = buf.len().min(remaining as usize);
+        let n = reader.read(&mut buf[..to_read])?;
+        if n == 0 {
+            break;
+        }
+
+        writer.write_all(&buf[..n])?;
+        total += n as u64;
+    }
+
+    Ok(total)
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,331 @@
+//! Generic extraction driver.
+//!
+//! The driver orchestrates extraction using adapters (format-specific) and
+//! policies (security checks).
+
+use std::fs;
+use std::io::{Read, Seek};
+use std::path::{Path, PathBuf};
+
+use crate::adapter::ZipAdapter;
+use crate::entry::{EntryInfo, EntryKind};
+use crate::error::Error;
+use crate::limits::Limits;
+use crate::policy::{
+    CountPolicy, DepthPolicy, ExtractionState, PathPolicy, PolicyChain, SizePolicy,
+    SymlinkBehavior, SymlinkPolicy,
+};
+
+/// What to do when a file already exists at the extraction path.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OverwriteMode {
+    /// Fail extraction if file exists. Safest default.
+    #[default]
+    Error,
+    /// Skip files that already exist.
+    Skip,
+    /// Overwrite existing files. Symlinks are removed before overwriting.
+    Overwrite,
+}
+
+/// Extraction mode determining validation strategy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ValidationMode {
+    /// Extract entries as they are read. Fast but leaves partial state on failure.
+    #[default]
+    Streaming,
+    /// Validate all entries first, then extract. Slower but atomic for validation failures.
+    ValidateFirst,
+}
+
+/// Extraction report with statistics.
+#[derive(Debug, Clone, Default)]
+pub struct ExtractionReport {
+    /// Number of files successfully extracted.
+    pub files_extracted: usize,
+    /// Number of directories created.
+    pub dirs_created: usize,
+    /// Total bytes written.
+    pub bytes_written: u64,
+    /// Number of entries skipped (symlinks, filtered, existing).
+    pub entries_skipped: usize,
+}
+
+/// Generic extraction driver that works with any archive format.
+///
+/// The driver uses:
+/// - **Adapters** to normalize archive formats into a common interface
+/// - **Policies** to validate entries before extraction
+///
+/// # Example
+///
+/// ```ignore
+/// use safe_unzip::{Driver, ZipAdapter};
+///
+/// let adapter = ZipAdapter::open("archive.zip")?;
+/// let report = Driver::new("/dest")?.extract_zip(adapter)?;
+/// ```
+pub struct Driver {
+    /// Destination directory.
+    destination: PathBuf,
+    /// Security limits.
+    limits: Limits,
+    /// What to do on existing files.
+    overwrite: OverwriteMode,
+    /// What to do with symlinks.
+    symlinks: SymlinkBehavior,
+    /// Validation strategy.
+    validation: ValidationMode,
+    /// Optional entry filter.
+    #[allow(clippy::type_complexity)]
+    filter: Option<Box<dyn Fn(&EntryInfo) -> bool + Send + Sync>>,
+}
+
+impl Driver {
+    /// Create a new driver for the given destination.
+    ///
+    /// Returns an error if the destination doesn't exist.
+    pub fn new<P: AsRef<Path>>(destination: P) -> Result<Self, Error> {
+        Self::new_impl(destination.as_ref(), false)
+    }
+
+    /// Create a new driver, creating the destination if it doesn't exist.
+    pub fn new_or_create<P: AsRef<Path>>(destination: P) -> Result<Self, Error> {
+        Self::new_impl(destination.as_ref(), true)
+    }
+
+    fn new_impl(destination: &Path, create: bool) -> Result<Self, Error> {
+        if !destination.exists() {
+            if create {
+                fs::create_dir_all(destination)?;
+            } else {
+                return Err(Error::DestinationNotFound {
+                    path: destination.to_string_lossy().to_string(),
+                });
+            }
+        }
+
+        Ok(Self {
+            destination: destination.to_path_buf(),
+            limits: Limits::default(),
+            overwrite: OverwriteMode::default(),
+            symlinks: SymlinkBehavior::default(),
+            validation: ValidationMode::default(),
+            filter: None,
+        })
+    }
+
+    /// Set extraction limits.
+    pub fn limits(mut self, limits: Limits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    /// Set overwrite mode.
+    pub fn overwrite(mut self, mode: OverwriteMode) -> Self {
+        self.overwrite = mode;
+        self
+    }
+
+    /// Set symlink handling.
+    pub fn symlinks(mut self, behavior: SymlinkBehavior) -> Self {
+        self.symlinks = behavior;
+        self
+    }
+
+    /// Set validation mode.
+    pub fn validation(mut self, mode: ValidationMode) -> Self {
+        self.validation = mode;
+        self
+    }
+
+    /// Set entry filter.
+    pub fn filter<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&EntryInfo) -> bool + Send + Sync + 'static,
+    {
+        self.filter = Some(Box::new(f));
+        self
+    }
+
+    /// Build the policy chain from current settings.
+    fn build_policies(&self) -> Result<PolicyChain, Error> {
+        Ok(PolicyChain::new()
+            .with(PathPolicy::new(&self.destination)?)
+            .with(SizePolicy::new(
+                self.limits.max_single_file,
+                self.limits.max_total_bytes,
+            ))
+            .with(CountPolicy::new(self.limits.max_file_count))
+            .with(DepthPolicy::new(self.limits.max_path_depth))
+            .with(SymlinkPolicy::new(self.symlinks)))
+    }
+
+    /// Extract a ZIP archive.
+    pub fn extract_zip<R: Read + Seek>(
+        &self,
+        mut adapter: ZipAdapter<R>,
+    ) -> Result<ExtractionReport, Error> {
+        let policies = self.build_policies()?;
+
+        // ValidateFirst mode: check all entries before extracting
+        if self.validation == ValidationMode::ValidateFirst {
+            self.validate_all_zip(&mut adapter, &policies)?;
+        }
+
+        let mut state = ExtractionState::default();
+
+        for i in 0..adapter.len() {
+            self.extract_zip_entry(&mut adapter, i, &policies, &mut state)?;
+        }
+
+        Ok(ExtractionReport {
+            files_extracted: state.files_extracted,
+            dirs_created: state.dirs_created,
+            bytes_written: state.bytes_written,
+            entries_skipped: state.entries_skipped,
+        })
+    }
+
+    /// Validate all entries without extracting.
+    fn validate_all_zip<R: Read + Seek>(
+        &self,
+        adapter: &mut ZipAdapter<R>,
+        policies: &PolicyChain,
+    ) -> Result<(), Error> {
+        let entries = adapter.entries_metadata()?;
+        let mut state = ExtractionState::default();
+
+        for info in entries {
+            policies.check_all(&info, &state)?;
+
+            // Update state for cumulative checks
+            if matches!(info.kind, EntryKind::File) {
+                state.bytes_written += info.size;
+                state.files_extracted += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extract a single ZIP entry.
+    fn extract_zip_entry<R: Read + Seek>(
+        &self,
+        adapter: &mut ZipAdapter<R>,
+        index: usize,
+        policies: &PolicyChain,
+        state: &mut ExtractionState,
+    ) -> Result<(), Error> {
+        let info = adapter.entry_info(index)?;
+
+        // Apply filter
+        if let Some(ref filter) = self.filter {
+            if !filter(&info) {
+                state.entries_skipped += 1;
+                return Ok(());
+            }
+        }
+
+        // Check policies
+        policies.check_all(&info, state)?;
+
+        // Handle symlinks (skip by default, policy may error)
+        if matches!(info.kind, EntryKind::Symlink { .. }) {
+            state.entries_skipped += 1;
+            return Ok(());
+        }
+
+        let safe_path = self.destination.join(&info.name);
+
+        // Extract based on entry type
+        match info.kind {
+            EntryKind::Directory => {
+                // For directories, just create (idempotent)
+                fs::create_dir_all(&safe_path)?;
+                state.dirs_created += 1;
+            }
+            EntryKind::File => {
+                if let Some(parent) = safe_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+
+                // Atomic file creation based on overwrite mode
+                let outfile = match self.overwrite {
+                    OverwriteMode::Error => {
+                        // create_new(true) is atomic: fails if file exists (no TOCTOU)
+                        match fs::OpenOptions::new()
+                            .write(true)
+                            .create_new(true)
+                            .open(&safe_path)
+                        {
+                            Ok(f) => f,
+                            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                                return Err(Error::AlreadyExists {
+                                    path: safe_path.display().to_string(),
+                                });
+                            }
+                            Err(e) => return Err(e.into()),
+                        }
+                    }
+                    OverwriteMode::Skip => {
+                        // Try atomic create, skip on exists
+                        match fs::OpenOptions::new()
+                            .write(true)
+                            .create_new(true)
+                            .open(&safe_path)
+                        {
+                            Ok(f) => f,
+                            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                                state.entries_skipped += 1;
+                                return Ok(());
+                            }
+                            Err(e) => return Err(e.into()),
+                        }
+                    }
+                    OverwriteMode::Overwrite => {
+                        // SECURITY: Remove any existing symlink first to prevent following
+                        if let Ok(m) = fs::symlink_metadata(&safe_path) {
+                            if m.file_type().is_symlink() {
+                                let _ = fs::remove_file(&safe_path);
+                            }
+                        }
+                        // Now create/truncate
+                        fs::File::create(&safe_path)?
+                    }
+                };
+
+                let mut outfile = outfile;
+                let limit = self.limits.max_single_file.min(
+                    self.limits
+                        .max_total_bytes
+                        .saturating_sub(state.bytes_written),
+                );
+
+                let (_, written) = adapter.extract_to(index, &mut outfile, limit)?;
+
+                // Set permissions on Unix
+                #[cfg(unix)]
+                if let Some(mode) = info.mode {
+                    use std::os::unix::fs::PermissionsExt;
+                    let safe_mode = mode & 0o0777;
+                    fs::set_permissions(&safe_path, fs::Permissions::from_mode(safe_mode))?;
+                }
+
+                state.bytes_written += written;
+                state.files_extracted += 1;
+            }
+            EntryKind::Symlink { .. } => {
+                // Already handled above (skipped or errored by policy)
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Convenience: extract from a file path.
+    pub fn extract_zip_file<P: AsRef<Path>>(&self, path: P) -> Result<ExtractionReport, Error> {
+        let adapter = ZipAdapter::open(path)?;
+        self.extract_zip(adapter)
+    }
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -262,7 +262,7 @@ impl Driver {
                             Ok(f) => f,
                             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                                 return Err(Error::AlreadyExists {
-                                    path: safe_path.display().to_string(),
+                                    entry: safe_path.display().to_string(),
                                 });
                             }
                             Err(e) => return Err(e.into()),
@@ -539,7 +539,7 @@ impl Driver {
                     Ok(f) => Ok(Some(f)),
                     Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                         Err(Error::AlreadyExists {
-                            path: path.display().to_string(),
+                            entry: path.display().to_string(),
                         })
                     }
                     Err(e) => Err(e.into()),

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,0 +1,91 @@
+//! Generic archive entry representation.
+//!
+//! This module defines the common `Entry` type that all archive adapters
+//! produce, enabling format-agnostic security policies.
+
+use std::io::Read;
+use std::path::Path;
+
+/// The type of entry in an archive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryKind {
+    /// A regular file.
+    File,
+    /// A directory.
+    Directory,
+    /// A symbolic link pointing to a target path.
+    Symlink { target: String },
+}
+
+/// A single entry in an archive.
+///
+/// This is the format-agnostic representation that all adapters produce.
+/// Security policies operate on this struct, not on format-specific types.
+pub struct Entry<'a> {
+    /// The path/name of the entry within the archive.
+    pub name: String,
+    /// The uncompressed size in bytes (may be declared, not actual).
+    pub size: u64,
+    /// The type of entry (file, directory, symlink).
+    pub kind: EntryKind,
+    /// Unix permissions (if available).
+    pub mode: Option<u32>,
+    /// A reader to access the entry's content.
+    pub reader: Box<dyn Read + 'a>,
+}
+
+impl<'a> Entry<'a> {
+    /// Returns true if this entry is a regular file.
+    pub fn is_file(&self) -> bool {
+        matches!(self.kind, EntryKind::File)
+    }
+
+    /// Returns true if this entry is a directory.
+    pub fn is_dir(&self) -> bool {
+        matches!(self.kind, EntryKind::Directory)
+    }
+
+    /// Returns true if this entry is a symbolic link.
+    pub fn is_symlink(&self) -> bool {
+        matches!(self.kind, EntryKind::Symlink { .. })
+    }
+
+    /// Returns the symlink target if this is a symlink.
+    pub fn symlink_target(&self) -> Option<&str> {
+        match &self.kind {
+            EntryKind::Symlink { target } => Some(target),
+            _ => None,
+        }
+    }
+
+    /// Returns the depth of the entry path (number of components).
+    pub fn depth(&self) -> usize {
+        Path::new(&self.name).components().count()
+    }
+}
+
+/// Information about an entry for policy decisions (without the reader).
+///
+/// Used for validation passes where we don't need to read content.
+#[derive(Debug, Clone)]
+pub struct EntryInfo {
+    /// The path/name of the entry within the archive.
+    pub name: String,
+    /// The uncompressed size in bytes.
+    pub size: u64,
+    /// The type of entry.
+    pub kind: EntryKind,
+    /// Unix permissions (if available).
+    pub mode: Option<u32>,
+}
+
+impl<'a> From<&Entry<'a>> for EntryInfo {
+    fn from(entry: &Entry<'a>) -> Self {
+        Self {
+            name: entry.name.clone(),
+            size: entry.size,
+            kind: entry.kind.clone(),
+            mode: entry.mode,
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,12 @@
 use std::fmt;
 
+/// Errors that can occur during archive extraction.
+///
+/// This enum is marked `#[non_exhaustive]` to allow adding new variants
+/// in minor versions without breaking existing code. Always include a
+/// catch-all `_ =>` arm when matching.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Path escapes destination directory (Zip Slip).
     PathEscape { entry: String, detail: String },

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
     /// Filename contains invalid characters or reserved names.
     InvalidFilename { entry: String, reason: String },
 
+    /// Archive entry is encrypted (not supported).
+    EncryptedEntry { entry: String },
+
     /// Zip format error.
     Zip(zip::result::ZipError),
 
@@ -140,6 +143,13 @@ impl fmt::Display for Error {
             }
             Self::InvalidFilename { entry, reason } => {
                 write!(f, "invalid filename '{}': {}", entry, reason)
+            }
+            Self::EncryptedEntry { entry } => {
+                write!(
+                    f,
+                    "entry '{}' is encrypted (encrypted archives not supported)",
+                    entry
+                )
             }
             Self::Zip(e) => write!(f, "zip format error: {}", e),
             Self::Io(e) => write!(f, "I/O error: {}", e),

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,7 +91,11 @@ impl fmt::Display for Error {
             }
             Self::SymlinkNotAllowed { entry, target } => {
                 if target.is_empty() {
-                    write!(f, "archive contains symlink '{}' (symlinks not allowed)", entry)
+                    write!(
+                        f,
+                        "archive contains symlink '{}' (symlinks not allowed)",
+                        entry
+                    )
                 } else {
                     write!(
                         f,

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -302,53 +302,6 @@ impl Extractor {
                 });
             }
 
-            // println!("DEBUG: Checking existence - Path: {:?}, Exists: {}", safe_path, safe_path.exists());
-            if safe_path.exists() || fs::symlink_metadata(&safe_path).is_ok() {
-                match self.overwrite {
-                    OverwritePolicy::Error => {
-                        // Only error if it really exists (exists() handles symlinks too) but we want to be careful
-                        if safe_path.exists() {
-                            return Err(Error::AlreadyExists {
-                                path: safe_path.display().to_string(),
-                            });
-                        }
-                    }
-                    OverwritePolicy::Skip => {
-                        if safe_path.exists() {
-                            report.entries_skipped += 1;
-                            continue;
-                        }
-                    }
-                    OverwritePolicy::Overwrite => {
-                        // SECURITY: Secure Overwrite
-                        // If it's a symlink, we MUST remove it to avoid following it.
-                        // If it's a file, we remove it to ensure clean state.
-                        // If it's a directory, we leave it (create_dir_all handles it),
-                        // unless it's a file trying to overwrite a dir... handling that is complex,
-                        // but fs::remove_file fails on dirs usually.
-
-                        // Use symlink_metadata to check type without following
-                        let meta = fs::symlink_metadata(&safe_path);
-                        if let Ok(m) = meta {
-                            if m.is_dir() {
-                                if !entry.is_dir() {
-                                    // Trying to overwrite dir with file...
-                                    // For now, let File::create fail or do nothing
-                                }
-                            } else {
-                                // Valid file or symlink - REMOVE IT
-                                if let Err(e) = fs::remove_file(&safe_path) {
-                                    // If it doesn't exist (race?), ignore. Else error.
-                                    if e.kind() != std::io::ErrorKind::NotFound {
-                                        return Err(Error::Io(e));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
             // 7. EXECUTION
             if entry.is_dir() {
                 fs::create_dir_all(&safe_path)?;
@@ -357,6 +310,52 @@ impl Extractor {
                 if let Some(parent) = safe_path.parent() {
                     fs::create_dir_all(parent)?;
                 }
+
+                // SECURITY: Atomic file creation based on overwrite policy
+                // Using create_new(true) eliminates TOCTOU race conditions
+                let outfile = match self.overwrite {
+                    OverwritePolicy::Error => {
+                        // create_new(true) is atomic: fails if file exists (no TOCTOU)
+                        match fs::OpenOptions::new()
+                            .write(true)
+                            .create_new(true)
+                            .open(&safe_path)
+                        {
+                            Ok(f) => f,
+                            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                                return Err(Error::AlreadyExists {
+                                    path: safe_path.display().to_string(),
+                                });
+                            }
+                            Err(e) => return Err(Error::Io(e)),
+                        }
+                    }
+                    OverwritePolicy::Skip => {
+                        // Try atomic create, skip on exists
+                        match fs::OpenOptions::new()
+                            .write(true)
+                            .create_new(true)
+                            .open(&safe_path)
+                        {
+                            Ok(f) => f,
+                            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                                report.entries_skipped += 1;
+                                continue;
+                            }
+                            Err(e) => return Err(Error::Io(e)),
+                        }
+                    }
+                    OverwritePolicy::Overwrite => {
+                        // SECURITY: Remove any existing symlink first to prevent following
+                        if let Ok(m) = fs::symlink_metadata(&safe_path) {
+                            if m.file_type().is_symlink() {
+                                let _ = fs::remove_file(&safe_path);
+                            }
+                        }
+                        // Now create/truncate
+                        fs::File::create(&safe_path)?
+                    }
+                };
 
                 // SECURITY: LimitReader
                 // Enforce:
@@ -372,7 +371,7 @@ impl Extractor {
                 let hard_limit = limit_single.min(remaining_global);
 
                 let mut limiter = LimitReader::new(&mut entry, hard_limit);
-                let mut outfile = fs::File::create(&safe_path)?;
+                let mut outfile = outfile;
 
                 // We use io::copy, which loops until EOF or error.
                 // LimitReader returns EOF at limit.

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -241,7 +241,7 @@ impl Extractor {
                         return Err(Error::SymlinkNotAllowed {
                             entry: name,
                             target: String::new(), // ZIP symlink targets require reading content
-                        })
+                        });
                     }
                     SymlinkPolicy::Skip => {
                         report.entries_skipped += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use extractor::{EntryInfo, ExtractionMode, Extractor, OverwritePolicy, Repor
 pub use limits::Limits;
 
 // Re-export new types
-pub use adapter::ZipAdapter;
+pub use adapter::{TarAdapter, ZipAdapter};
 pub use driver::{Driver, ExtractionReport, OverwriteMode, ValidationMode};
 pub use entry::{Entry, EntryKind};
 pub use policy::{Policy, PolicyChain, PolicyConfig, SymlinkBehavior};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,21 @@ mod error;
 mod extractor;
 mod limits;
 
+// New architecture modules (v0.2)
+pub mod adapter;
+mod driver;
+pub mod entry;
+pub mod policy;
+
 pub use error::Error;
 pub use extractor::{EntryInfo, ExtractionMode, Extractor, OverwritePolicy, Report, SymlinkPolicy};
 pub use limits::Limits;
+
+// Re-export new types
+pub use adapter::ZipAdapter;
+pub use driver::{Driver, ExtractionReport, OverwriteMode, ValidationMode};
+pub use entry::{Entry, EntryKind};
+pub use policy::{Policy, PolicyChain, PolicyConfig, SymlinkBehavior};
 
 /// Extract from a reader with default settings.
 ///

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,332 @@
+//! Security policies for archive extraction.
+//!
+//! Policies validate entries before they are extracted, providing
+//! protection against various archive-based attacks.
+
+use std::path::{Component, Path, PathBuf};
+
+use path_jail::Jail;
+
+use crate::entry::{EntryInfo, EntryKind};
+use crate::error::Error;
+
+/// State tracked during extraction for cumulative limit checks.
+#[derive(Debug, Clone, Default)]
+pub struct ExtractionState {
+    /// Number of files extracted so far.
+    pub files_extracted: usize,
+    /// Number of directories created.
+    pub dirs_created: usize,
+    /// Total bytes written so far.
+    pub bytes_written: u64,
+    /// Entries skipped (symlinks, filtered, etc.).
+    pub entries_skipped: usize,
+}
+
+/// A security policy that validates entries before extraction.
+pub trait Policy: Send + Sync {
+    /// Validate an entry against this policy.
+    ///
+    /// Returns `Ok(())` if the entry passes, or an error if it violates the policy.
+    fn check(&self, entry: &EntryInfo, state: &ExtractionState) -> Result<(), Error>;
+}
+
+/// A chain of policies that all must pass.
+pub struct PolicyChain {
+    policies: Vec<Box<dyn Policy>>,
+}
+
+impl PolicyChain {
+    /// Create a new empty policy chain.
+    pub fn new() -> Self {
+        Self {
+            policies: Vec::new(),
+        }
+    }
+
+    /// Add a policy to the chain.
+    pub fn with<P: Policy + 'static>(mut self, policy: P) -> Self {
+        self.policies.push(Box::new(policy));
+        self
+    }
+
+    /// Check all policies against an entry.
+    pub fn check_all(&self, entry: &EntryInfo, state: &ExtractionState) -> Result<(), Error> {
+        for policy in &self.policies {
+            policy.check(entry, state)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for PolicyChain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Path Security Policy
+// ============================================================================
+
+/// Policy that prevents path traversal attacks (Zip Slip).
+pub struct PathPolicy {
+    jail: Jail,
+}
+
+impl PathPolicy {
+    /// Create a new path policy for the given destination.
+    pub fn new(destination: &Path) -> Result<Self, Error> {
+        let jail = Jail::new(destination).map_err(|e| Error::PathEscape {
+            entry: destination.display().to_string(),
+            detail: e.to_string(),
+        })?;
+        Ok(Self { jail })
+    }
+
+    /// Validate a filename for security issues.
+    fn validate_filename(name: &str) -> Result<(), &'static str> {
+        // Reject empty names
+        if name.is_empty() {
+            return Err("empty filename");
+        }
+
+        // Reject control characters (includes null bytes)
+        if name.chars().any(|c| c.is_control()) {
+            return Err("contains control characters");
+        }
+
+        // Reject backslashes (Windows path separator could bypass Unix checks)
+        if name.contains('\\') {
+            return Err("contains backslash");
+        }
+
+        // Reject extremely long filenames
+        if name.len() > 1024 {
+            return Err("path too long (>1024 bytes)");
+        }
+
+        if name.split('/').any(|component| component.len() > 255) {
+            return Err("path component too long (>255 bytes)");
+        }
+
+        // Reject Windows reserved names
+        for component in Path::new(name).components() {
+            if let Component::Normal(s) = component {
+                if let Some(s) = s.to_str() {
+                    let s_upper = s.to_ascii_uppercase();
+                    let file_stem = s_upper.split('.').next().unwrap_or(&s_upper);
+
+                    match file_stem {
+                        "CON" | "PRN" | "AUX" | "NUL" | "COM1" | "COM2" | "COM3" | "COM4"
+                        | "COM5" | "COM6" | "COM7" | "COM8" | "COM9" | "LPT1" | "LPT2" | "LPT3"
+                        | "LPT4" | "LPT5" | "LPT6" | "LPT7" | "LPT8" | "LPT9" => {
+                            return Err("Windows reserved name");
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Policy for PathPolicy {
+    fn check(&self, entry: &EntryInfo, _state: &ExtractionState) -> Result<(), Error> {
+        // Validate filename syntax
+        if let Err(reason) = Self::validate_filename(&entry.name) {
+            return Err(Error::InvalidFilename {
+                entry: entry.name.clone(),
+                reason: reason.to_string(),
+            });
+        }
+
+        // Check path jail (prevents traversal)
+        self.jail.join(&entry.name).map_err(|e| Error::PathEscape {
+            entry: entry.name.clone(),
+            detail: e.to_string(),
+        })?;
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Size Limits Policy
+// ============================================================================
+
+/// Policy that enforces size limits to prevent zip bombs.
+pub struct SizePolicy {
+    /// Maximum size of a single file.
+    pub max_single_file: u64,
+    /// Maximum total bytes across all files.
+    pub max_total: u64,
+}
+
+impl SizePolicy {
+    /// Create a new size policy with the given limits.
+    pub fn new(max_single_file: u64, max_total: u64) -> Self {
+        Self {
+            max_single_file,
+            max_total,
+        }
+    }
+}
+
+impl Policy for SizePolicy {
+    fn check(&self, entry: &EntryInfo, state: &ExtractionState) -> Result<(), Error> {
+        // Check single file limit
+        if entry.size > self.max_single_file {
+            return Err(Error::FileTooLarge {
+                entry: entry.name.clone(),
+                limit: self.max_single_file,
+                size: entry.size,
+            });
+        }
+
+        // Check total size limit
+        if state.bytes_written + entry.size > self.max_total {
+            return Err(Error::TotalSizeExceeded {
+                limit: self.max_total,
+                would_be: state.bytes_written + entry.size,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// File Count Policy
+// ============================================================================
+
+/// Policy that enforces a maximum file count.
+pub struct CountPolicy {
+    /// Maximum number of files.
+    pub max_files: usize,
+}
+
+impl CountPolicy {
+    /// Create a new count policy.
+    pub fn new(max_files: usize) -> Self {
+        Self { max_files }
+    }
+}
+
+impl Policy for CountPolicy {
+    fn check(&self, _entry: &EntryInfo, state: &ExtractionState) -> Result<(), Error> {
+        if state.files_extracted >= self.max_files {
+            return Err(Error::FileCountExceeded {
+                limit: self.max_files,
+                attempted: state.files_extracted + 1,
+            });
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Path Depth Policy
+// ============================================================================
+
+/// Policy that enforces a maximum path depth.
+pub struct DepthPolicy {
+    /// Maximum directory depth.
+    pub max_depth: usize,
+}
+
+impl DepthPolicy {
+    /// Create a new depth policy.
+    pub fn new(max_depth: usize) -> Self {
+        Self { max_depth }
+    }
+}
+
+impl Policy for DepthPolicy {
+    fn check(&self, entry: &EntryInfo, _state: &ExtractionState) -> Result<(), Error> {
+        let depth = Path::new(&entry.name).components().count();
+        if depth > self.max_depth {
+            return Err(Error::PathTooDeep {
+                entry: entry.name.clone(),
+                depth,
+                limit: self.max_depth,
+            });
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Symlink Policy
+// ============================================================================
+
+/// What to do when encountering a symlink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SymlinkBehavior {
+    /// Skip symlinks silently.
+    #[default]
+    Skip,
+    /// Return an error if a symlink is encountered.
+    Error,
+}
+
+/// Policy that handles symlinks in archives.
+pub struct SymlinkPolicy {
+    /// What to do with symlinks.
+    pub behavior: SymlinkBehavior,
+}
+
+impl SymlinkPolicy {
+    /// Create a new symlink policy.
+    pub fn new(behavior: SymlinkBehavior) -> Self {
+        Self { behavior }
+    }
+}
+
+impl Policy for SymlinkPolicy {
+    fn check(&self, entry: &EntryInfo, _state: &ExtractionState) -> Result<(), Error> {
+        if matches!(entry.kind, EntryKind::Symlink { .. }) {
+            match self.behavior {
+                SymlinkBehavior::Skip => {
+                    // This will be handled by the extractor by skipping
+                    // We don't error here, just let the extractor know to skip
+                }
+                SymlinkBehavior::Error => {
+                    return Err(Error::SymlinkNotAllowed {
+                        entry: entry.name.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Default Policy Chain Builder
+// ============================================================================
+
+/// Configuration for building a default policy chain.
+#[derive(Debug, Clone)]
+pub struct PolicyConfig {
+    pub destination: PathBuf,
+    pub max_single_file: u64,
+    pub max_total: u64,
+    pub max_files: usize,
+    pub max_depth: usize,
+    pub symlink_behavior: SymlinkBehavior,
+}
+
+impl PolicyConfig {
+    /// Build a policy chain from this configuration.
+    pub fn build(&self) -> Result<PolicyChain, Error> {
+        Ok(PolicyChain::new()
+            .with(PathPolicy::new(&self.destination)?)
+            .with(SizePolicy::new(self.max_single_file, self.max_total))
+            .with(CountPolicy::new(self.max_files))
+            .with(DepthPolicy::new(self.max_depth))
+            .with(SymlinkPolicy::new(self.symlink_behavior)))
+    }
+}

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -287,7 +287,7 @@ impl SymlinkPolicy {
 
 impl Policy for SymlinkPolicy {
     fn check(&self, entry: &EntryInfo, _state: &ExtractionState) -> Result<(), Error> {
-        if matches!(entry.kind, EntryKind::Symlink { .. }) {
+        if let EntryKind::Symlink { target } = &entry.kind {
             match self.behavior {
                 SymlinkBehavior::Skip => {
                     // This will be handled by the extractor by skipping
@@ -296,6 +296,7 @@ impl Policy for SymlinkPolicy {
                 SymlinkBehavior::Error => {
                     return Err(Error::SymlinkNotAllowed {
                         entry: entry.name.clone(),
+                        target: target.clone(),
                     });
                 }
             }

--- a/tests/driver_test.rs
+++ b/tests/driver_test.rs
@@ -1,0 +1,264 @@
+//! Tests for the new Driver-based architecture.
+
+use safe_unzip::{Driver, OverwriteMode, ValidationMode, ZipAdapter};
+use std::io::Write;
+use tempfile::tempdir;
+use zip::write::FileOptions;
+
+/// Helper to create a simple zip with one file.
+fn create_simple_zip(name: &str, content: &[u8]) -> std::fs::File {
+    let file = tempfile::tempfile().unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options: FileOptions<()> = FileOptions::default();
+    zip.start_file(name, options).unwrap();
+    zip.write_all(content).unwrap();
+    zip.finish().unwrap()
+}
+
+/// Helper to create a zip with multiple files.
+fn create_multi_file_zip(files: &[(&str, &[u8])]) -> std::fs::File {
+    let file = tempfile::tempfile().unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options: FileOptions<()> = FileOptions::default();
+
+    for (name, content) in files {
+        zip.start_file(*name, options).unwrap();
+        zip.write_all(content).unwrap();
+    }
+
+    zip.finish().unwrap()
+}
+
+#[test]
+fn test_driver_basic_extraction() {
+    let dest = tempdir().unwrap();
+    let zip_file = create_simple_zip("hello.txt", b"Hello, World!");
+
+    let adapter = ZipAdapter::new(zip_file).unwrap();
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .extract_zip(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 1);
+    assert_eq!(report.bytes_written, 13);
+    assert!(dest.path().join("hello.txt").exists());
+
+    let content = std::fs::read_to_string(dest.path().join("hello.txt")).unwrap();
+    assert_eq!(content, "Hello, World!");
+
+    println!("✅ Driver basic extraction works");
+}
+
+#[test]
+fn test_driver_multiple_files() {
+    let dest = tempdir().unwrap();
+    let zip_file = create_multi_file_zip(&[
+        ("a.txt", b"aaa"),
+        ("b.txt", b"bbb"),
+        ("subdir/c.txt", b"ccc"),
+    ]);
+
+    let adapter = ZipAdapter::new(zip_file).unwrap();
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .extract_zip(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 3);
+    assert!(dest.path().join("a.txt").exists());
+    assert!(dest.path().join("subdir/c.txt").exists());
+
+    println!("✅ Driver multiple files extraction works");
+}
+
+#[test]
+fn test_driver_blocks_path_traversal() {
+    let dest = tempdir().unwrap();
+    let zip_file = create_simple_zip("../../etc/passwd", b"evil");
+
+    let adapter = ZipAdapter::new(zip_file).unwrap();
+    let result = Driver::new(dest.path()).unwrap().extract_zip(adapter);
+
+    assert!(result.is_err());
+    println!("✅ Driver blocks path traversal");
+}
+
+#[test]
+fn test_driver_validate_first_mode() {
+    let dest = tempdir().unwrap();
+
+    // Create zip with valid file then traversal attempt
+    let file = tempfile::tempfile().unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options: FileOptions<()> = FileOptions::default();
+
+    zip.start_file("good.txt", options).unwrap();
+    zip.write_all(b"This is fine").unwrap();
+
+    zip.start_file("../../evil.txt", options).unwrap();
+    zip.write_all(b"pwned").unwrap();
+
+    let zip_file = zip.finish().unwrap();
+
+    let adapter = ZipAdapter::new(zip_file).unwrap();
+    let result = Driver::new(dest.path())
+        .unwrap()
+        .validation(ValidationMode::ValidateFirst)
+        .extract_zip(adapter);
+
+    // Should fail
+    assert!(result.is_err());
+
+    // Nothing should be written in ValidateFirst mode
+    assert!(
+        !dest.path().join("good.txt").exists(),
+        "ValidateFirst should not write good.txt before failing"
+    );
+
+    println!("✅ Driver ValidateFirst mode works");
+}
+
+#[test]
+fn test_driver_overwrite_error() {
+    let dest = tempdir().unwrap();
+
+    // First extraction
+    let zip1 = create_simple_zip("test.txt", b"original");
+    let adapter1 = ZipAdapter::new(zip1).unwrap();
+    Driver::new(dest.path())
+        .unwrap()
+        .extract_zip(adapter1)
+        .unwrap();
+
+    // Second extraction should fail (default is Error)
+    let zip2 = create_simple_zip("test.txt", b"modified");
+    let adapter2 = ZipAdapter::new(zip2).unwrap();
+    let result = Driver::new(dest.path())
+        .unwrap()
+        .overwrite(OverwriteMode::Error)
+        .extract_zip(adapter2);
+
+    assert!(result.is_err());
+
+    // Content should be unchanged
+    let content = std::fs::read_to_string(dest.path().join("test.txt")).unwrap();
+    assert_eq!(content, "original");
+
+    println!("✅ Driver OverwriteMode::Error works");
+}
+
+#[test]
+fn test_driver_overwrite_skip() {
+    let dest = tempdir().unwrap();
+
+    // First extraction
+    let zip1 = create_simple_zip("test.txt", b"original");
+    let adapter1 = ZipAdapter::new(zip1).unwrap();
+    Driver::new(dest.path())
+        .unwrap()
+        .extract_zip(adapter1)
+        .unwrap();
+
+    // Second extraction with Skip
+    let zip2 = create_simple_zip("test.txt", b"modified");
+    let adapter2 = ZipAdapter::new(zip2).unwrap();
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .overwrite(OverwriteMode::Skip)
+        .extract_zip(adapter2)
+        .unwrap();
+
+    assert_eq!(report.entries_skipped, 1);
+
+    // Content should be unchanged
+    let content = std::fs::read_to_string(dest.path().join("test.txt")).unwrap();
+    assert_eq!(content, "original");
+
+    println!("✅ Driver OverwriteMode::Skip works");
+}
+
+#[test]
+fn test_driver_overwrite_overwrite() {
+    let dest = tempdir().unwrap();
+
+    // First extraction
+    let zip1 = create_simple_zip("test.txt", b"original");
+    let adapter1 = ZipAdapter::new(zip1).unwrap();
+    Driver::new(dest.path())
+        .unwrap()
+        .extract_zip(adapter1)
+        .unwrap();
+
+    // Second extraction with Overwrite
+    let zip2 = create_simple_zip("test.txt", b"modified");
+    let adapter2 = ZipAdapter::new(zip2).unwrap();
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .overwrite(OverwriteMode::Overwrite)
+        .extract_zip(adapter2)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 1);
+
+    // Content should be updated
+    let content = std::fs::read_to_string(dest.path().join("test.txt")).unwrap();
+    assert_eq!(content, "modified");
+
+    println!("✅ Driver OverwriteMode::Overwrite works");
+}
+
+#[test]
+fn test_driver_filter() {
+    let dest = tempdir().unwrap();
+    let zip_file = create_multi_file_zip(&[
+        ("image.png", b"png data"),
+        ("document.txt", b"text data"),
+        ("photo.jpg", b"jpg data"),
+    ]);
+
+    let adapter = ZipAdapter::new(zip_file).unwrap();
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .filter(|info| info.name.ends_with(".txt"))
+        .extract_zip(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 1);
+    assert!(dest.path().join("document.txt").exists());
+    assert!(!dest.path().join("image.png").exists());
+    assert!(!dest.path().join("photo.jpg").exists());
+
+    println!("✅ Driver filter works");
+}
+
+#[test]
+fn test_driver_atomic_file_creation() {
+    // Test that OverwriteMode::Error uses atomic creation
+    // This is a basic test - race conditions are hard to test deterministically
+    let dest = tempdir().unwrap();
+
+    // Create a file first
+    std::fs::write(dest.path().join("existing.txt"), "original").unwrap();
+
+    // Create a zip that tries to extract to the same name
+    let zip_file = create_simple_zip("existing.txt", b"new content");
+
+    let adapter = ZipAdapter::new(zip_file).unwrap();
+    let result = Driver::new(dest.path())
+        .unwrap()
+        .overwrite(OverwriteMode::Error)
+        .extract_zip(adapter);
+
+    // Should fail with AlreadyExists
+    assert!(matches!(
+        result,
+        Err(safe_unzip::Error::AlreadyExists { .. })
+    ));
+
+    // Original content should be preserved
+    let content = std::fs::read_to_string(dest.path().join("existing.txt")).unwrap();
+    assert_eq!(content, "original");
+
+    println!("✅ Driver atomic file creation works");
+}

--- a/tests/tar_test.rs
+++ b/tests/tar_test.rs
@@ -1,0 +1,256 @@
+//! Tests for TAR archive extraction.
+
+use safe_unzip::{Driver, TarAdapter, ValidationMode};
+use std::io::Write;
+use tempfile::tempdir;
+
+/// Create a simple tar archive with one file.
+fn create_simple_tar(name: &str, content: &[u8]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+
+    let mut header = tar::Header::new_gnu();
+    header.set_path(name).unwrap();
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+
+    builder.append(&header, content).unwrap();
+    builder.into_inner().unwrap()
+}
+
+/// Create a tar archive with multiple files.
+fn create_multi_file_tar(files: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+
+    for (name, content) in files {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(*name).unwrap();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+
+        builder.append(&header, *content).unwrap();
+    }
+
+    builder.into_inner().unwrap()
+}
+
+/// Create a tar archive with a directory.
+fn create_tar_with_dir(dir_name: &str, file_name: &str, content: &[u8]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+
+    // Add directory
+    let mut header = tar::Header::new_gnu();
+    header.set_path(dir_name).unwrap();
+    header.set_size(0);
+    header.set_mode(0o755);
+    header.set_entry_type(tar::EntryType::Directory);
+    header.set_cksum();
+    builder.append(&header, &[][..]).unwrap();
+
+    // Add file in directory
+    let full_path = format!("{}/{}", dir_name.trim_end_matches('/'), file_name);
+    let mut header = tar::Header::new_gnu();
+    header.set_path(&full_path).unwrap();
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append(&header, content).unwrap();
+
+    builder.into_inner().unwrap()
+}
+
+#[test]
+fn test_tar_basic_extraction() {
+    let dest = tempdir().unwrap();
+    let tar_data = create_simple_tar("hello.txt", b"Hello, TAR!");
+
+    let adapter = TarAdapter::new(std::io::Cursor::new(tar_data));
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .extract_tar(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 1);
+    assert_eq!(report.bytes_written, 11);
+    assert!(dest.path().join("hello.txt").exists());
+
+    let content = std::fs::read_to_string(dest.path().join("hello.txt")).unwrap();
+    assert_eq!(content, "Hello, TAR!");
+
+    println!("✅ TAR basic extraction works");
+}
+
+#[test]
+fn test_tar_multiple_files() {
+    let dest = tempdir().unwrap();
+    let tar_data =
+        create_multi_file_tar(&[("a.txt", b"aaa"), ("b.txt", b"bbb"), ("c.txt", b"ccc")]);
+
+    let adapter = TarAdapter::new(std::io::Cursor::new(tar_data));
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .extract_tar(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 3);
+    assert!(dest.path().join("a.txt").exists());
+    assert!(dest.path().join("b.txt").exists());
+    assert!(dest.path().join("c.txt").exists());
+
+    println!("✅ TAR multiple files extraction works");
+}
+
+#[test]
+fn test_tar_with_directory() {
+    let dest = tempdir().unwrap();
+    let tar_data = create_tar_with_dir("subdir/", "file.txt", b"in subdir");
+
+    let adapter = TarAdapter::new(std::io::Cursor::new(tar_data));
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .extract_tar(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 1);
+    assert_eq!(report.dirs_created, 1);
+    assert!(dest.path().join("subdir/file.txt").exists());
+
+    println!("✅ TAR with directory works");
+}
+
+#[test]
+fn test_tar_blocks_path_traversal() {
+    let dest = tempdir().unwrap();
+
+    // Create a tar with path traversal attempt using raw bytes
+    // The tar crate's set_path() blocks "..", so we manually construct the header
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+
+    // Use a safe path first, then modify the raw bytes
+    header.set_path("placeholder").unwrap();
+    header.set_size(4);
+    header.set_mode(0o644);
+
+    // Manually set the path in the header bytes
+    let evil_path = b"../../etc/passwd";
+    header.as_mut_bytes()[..evil_path.len()].copy_from_slice(evil_path);
+    header.as_mut_bytes()[evil_path.len()] = 0; // Null terminate
+
+    header.set_cksum();
+    builder.append(&header, &b"evil"[..]).unwrap();
+    let tar_data = builder.into_inner().unwrap();
+
+    let adapter = TarAdapter::new(std::io::Cursor::new(tar_data));
+    let result = Driver::new(dest.path()).unwrap().extract_tar(adapter);
+
+    assert!(result.is_err());
+    println!("✅ TAR blocks path traversal");
+}
+
+#[test]
+fn test_tar_validate_first_mode() {
+    let dest = tempdir().unwrap();
+
+    // Create tar with valid file then traversal attempt
+    let mut builder = tar::Builder::new(Vec::new());
+
+    // Good file
+    let mut header = tar::Header::new_gnu();
+    header.set_path("good.txt").unwrap();
+    header.set_size(12);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append(&header, &b"This is fine"[..]).unwrap();
+
+    // Bad file (path traversal) - manually set path to bypass tar crate's check
+    let mut header = tar::Header::new_gnu();
+    header.set_path("placeholder").unwrap();
+    header.set_size(5);
+    header.set_mode(0o644);
+
+    let evil_path = b"../../evil.txt";
+    header.as_mut_bytes()[..evil_path.len()].copy_from_slice(evil_path);
+    header.as_mut_bytes()[evil_path.len()] = 0;
+
+    header.set_cksum();
+    builder.append(&header, &b"pwned"[..]).unwrap();
+
+    let tar_data = builder.into_inner().unwrap();
+
+    let adapter = TarAdapter::new(std::io::Cursor::new(tar_data));
+    let result = Driver::new(dest.path())
+        .unwrap()
+        .validation(ValidationMode::ValidateFirst)
+        .extract_tar(adapter);
+
+    // Should fail
+    assert!(result.is_err());
+
+    // Nothing should be written in ValidateFirst mode
+    assert!(
+        !dest.path().join("good.txt").exists(),
+        "ValidateFirst should not write good.txt before failing"
+    );
+
+    println!("✅ TAR ValidateFirst mode works");
+}
+
+#[test]
+fn test_tar_filter() {
+    let dest = tempdir().unwrap();
+    let tar_data = create_multi_file_tar(&[
+        ("image.png", b"png data"),
+        ("document.txt", b"text data"),
+        ("photo.jpg", b"jpg data"),
+    ]);
+
+    let adapter = TarAdapter::new(std::io::Cursor::new(tar_data));
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .filter(|info| info.name.ends_with(".txt"))
+        .extract_tar(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 1);
+    assert!(dest.path().join("document.txt").exists());
+    assert!(!dest.path().join("image.png").exists());
+    assert!(!dest.path().join("photo.jpg").exists());
+
+    println!("✅ TAR filter works");
+}
+
+#[test]
+fn test_tar_gz_extraction() {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+
+    let dest = tempdir().unwrap();
+
+    // Create tar data
+    let tar_data = create_simple_tar("compressed.txt", b"I was compressed!");
+
+    // Compress with gzip
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_data).unwrap();
+    let gz_data = encoder.finish().unwrap();
+
+    // Extract using GzDecoder
+    use flate2::read::GzDecoder;
+    let decoder = GzDecoder::new(std::io::Cursor::new(gz_data));
+    let adapter = TarAdapter::new(decoder);
+
+    let report = Driver::new(dest.path())
+        .unwrap()
+        .extract_tar(adapter)
+        .unwrap();
+
+    assert_eq!(report.files_extracted, 1);
+    assert!(dest.path().join("compressed.txt").exists());
+
+    let content = std::fs::read_to_string(dest.path().join("compressed.txt")).unwrap();
+    assert_eq!(content, "I was compressed!");
+
+    println!("✅ TAR.GZ extraction works");
+}

--- a/tests/tar_test.rs
+++ b/tests/tar_test.rs
@@ -392,8 +392,7 @@ fn test_tar_blocks_absolute_path() {
             );
             // Should be inside the jail with leading slash stripped
             assert!(
-                dest.path().join("etc/passwd").exists()
-                    || dest.path().join("passwd").exists(),
+                dest.path().join("etc/passwd").exists() || dest.path().join("passwd").exists(),
                 "Should be extracted inside jail"
             );
             println!("✅ TAR blocks absolute path (sanitized)");


### PR DESCRIPTION
Architecture:
- New adapter/policy/driver architecture for multi-format support
- Entry, EntryKind, EntryInfo for format-agnostic entries
- ZipAdapter wraps zip crate with encryption detection
- PolicyChain with PathPolicy, SizePolicy, CountPolicy, DepthPolicy, SymlinkPolicy
- Driver orchestrates extraction using adapters and policies

Security:
- Encrypted archives rejected with Error::EncryptedEntry
- Atomic file creation (O_CREAT|O_EXCL) for Error/Skip modes
- Eliminates TOCTOU race between exists check and create

Fuzzing:
- cargo-fuzz setup with two targets
- fuzz_extract: tests full extraction pipeline
- fuzz_zip_adapter: tests parsing layer

Tests:
- 9 new driver tests
- test_driver_atomic_file_creation validates atomic behavior

Docs:
- Encrypted Archives section explaining the limitation
- TOCTOU Mitigations section
- Fuzzing instructions